### PR TITLE
Fixed db_get_byteswapped

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -229,7 +229,7 @@ db_exists <- function(dbh, txnid=NULL, key, flags=0L) {
 db_truncate <- function(dhh) { }
 
 db_get_byteswapped <- function(dbh) {
-  .Call("rberkeley_db_get_byteswapped", dbh)
+  .Call("rberkeley_db_get_byteswapped", as.DB(dbh)) 
 }
 
 db_set_cachesize <- function(dbh, gbytes, bytes, ncache) {


### PR DESCRIPTION
as.DB() was missing in `.Call("rberkeley_db_get_byteswapped", dbh)` which produced an error when `db_get_byteswapped`  was executed