### PR TITLE
Update utils.c

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1,8 +1,3 @@
-#pragma GCC diagnostic ignored "-Wswitch"
-
-#include <R.h>
-#include <Rinternals.h>
-#include <Rdefines.h>
 /* #include "db.h" */
 #include "config.h"
 #include DB_HEADER


### PR DESCRIPTION
Removed Diagnostic flag 'Wswitch' because it remains enabled by default.

Also there are no files like R.h, Rinternals.h, and Rdefines.h anywehere in package.

After this edit, 1 ERROR, 4 WARNINGS, and 1 NOTE was eradicated.

Here are attached previous and current checklog of package.
[02check.log](https://github.com/hrbrmstr/RBerkeley/files/3038444/02check.log)
[03check.log](https://github.com/hrbrmstr/RBerkeley/files/3038446/03check.log)

